### PR TITLE
Change to template literal

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,5 +54,5 @@ server.get('/rates', function respond(req, res, next) {
 });
 
 server.listen(process.env.PORT || 8080, function() {
-	console.log('%s listening at %s', server.name, server.url);
+	console.log(`${server.name} listening at ${server.url}`);
 });


### PR DESCRIPTION
I noticed that this is using something common in scripting languages like Python or Lua. It's perfectly acceptable practice, but why not just use a template literal? It should work the same way and because the mighty ECMAScript gods have graced us with beautiful ES6, it's quite a lot nicer practice and easier to read.