### PR TITLE
Add checking for same-currency conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ server.get('/transaction/:user/:amount/:to', function respond(req, res, next) {
 		res.sendRaw(429, '[Declined] Daily per user limit exceeded. The currency '+rate.code+' has a daily transaction limit of '+rate.limit.daily+' Discoins per user. The user can still exchange a total of '+balance+' Discoins into the currency '+rate.code+' for today.'); // If they exceeded, decline
 		return;
 	}
+	else if (req.params.to === rate.code) {
+		res.sendRaw(400, '[ERROR] Can not convert into same currency!')
 	else {
 		limits.splice(limits.indexOf(limit), 1); // Remove old limit
 		limit.limits.splice(limits.indexOf(slimit), 1); // Remove old code-specific limit from the limit

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ server.get('/transaction/:user/:amount/:to', function respond(req, res, next) {
 	}
 	else if (req.params.to === rate.code) {
 		res.sendRaw(400, '[ERROR] Can not convert into same currency!')
+	}
 	else {
 		limits.splice(limits.indexOf(limit), 1); // Remove old limit
 		limit.limits.splice(limits.indexOf(slimit), 1); // Remove old code-specific limit from the limit


### PR DESCRIPTION
From the context clues in the code, this should be functional.
This would prevent users from transferring from one currency back into the same currency. Just seems like a bit of a logic flaw there.